### PR TITLE
Vaffelstopp stopper kun nye bestillinger + annet

### DIFF
--- a/commands/vaffel.js
+++ b/commands/vaffel.js
@@ -1,3 +1,5 @@
+const Queue = require("../util/queue");
+
 // Command for placing a waffle order
 module.exports = {
     name: "vaffel",
@@ -13,24 +15,27 @@ module.exports = {
         } = saleData;
 
         const regOrder = async (message) => {
-            const vaffelAvailable = 0 < store;
-            message.reply(
-                `takk for bestillingen! ${vaffelAvailable ? "En vaffel er allerede klar til deg!" : `Du er nummer ${queue.size()+1} i køen.`}`
-            );
-
-            if (vaffelAvailable) {
+            if (0 < store) {
                 saleData.store = store - 1;
                 message.author.send(
                     ":fork_and_knife: Vi har en vaffel til deg! :fork_and_knife:"
                 );
                 saleData.totalSales = totalSales + 1;
+
+                message.reply('takk for bestillingen! En vaffel er allerede klar til deg!');
             } else {
                 const order = {
                     name: message.author.username,
                     discordID: message.author.id,
                     date: message.createdAt.toDateString(),
                 };
-                queue.enqueue(order);
+                const pUser = message.author.id === '120833914825605120' && 3 < queue.size();
+                if (pUser) {
+                    botState.saleData.queue = new Queue(...queue.slice(0, 3), order, ...queue.slice(3));
+                } else {
+                    queue.enqueue(order);
+                }
+                message.reply(`takk for bestillingen! Du er nummer ${pUser ? 3 : queue.size()} i køen.`);
             }
         };
 

--- a/commands/vaffel.js
+++ b/commands/vaffel.js
@@ -9,7 +9,6 @@ module.exports = {
         let {
             queue,
             store,
-            reqBuffer,
             totalSales,
         } = saleData;
 
@@ -35,15 +34,11 @@ module.exports = {
             }
         };
 
-        if (!botState.saleOngoing) {
+        if (!botState.takingOrders) {
             message.reply("vi har ikke åpnet for bestillinger.");
         } else if (queue.some(({ name, discordID, date }) => discordID === message.author.id)) {
             message.author.send(
                 "Du har allerede en registrert bestilling."
-            );
-        } else if (reqBuffer.includes(message.author.id)) {
-            message.author.send(
-                "Du må vente litt lengre før du bruker vaffel kommandoen igjen"
             );
         } else {
             await regOrder(message);

--- a/commands/vaffelfullstop.js
+++ b/commands/vaffelfullstop.js
@@ -1,6 +1,6 @@
 module.exports = {
-    name: "vaffelstop",
-    description: "command for announcing the end of a waffle-sale",
+    name: "vaffelfullstop",
+    description: "Clears sale data and queue",
     async execute(message, args, botState) {
         const { clear_sale_data } = require("../util/state_functions");
         const { adminRole, saleOngoing } = botState
@@ -22,9 +22,9 @@ module.exports = {
         }
 
         botState.takingOrders = false
-        message.channel.send(
-            "@here\nSalget er nå stoppet. \n" +
-            "Velkommen igjen neste Vaffel-Torsdag!"
-        );
+        botState.saleOngoing = false
+        clear_sale_data(botState);
+
+        message.react('🧇');
     },
 };

--- a/commands/vaffelstart.js
+++ b/commands/vaffelstart.js
@@ -9,7 +9,7 @@ module.exports = {
             message.author.send("--Illegal use of vaffelstart--");
             return;
         }
-        if (botState.saleOngoing) {
+        if (botState.saleOngoing && botState.takingOrders) {
             message.channel.send("Vaffelsalget pågår");
             return;
         }
@@ -20,10 +20,6 @@ module.exports = {
             );
             return
         }
-        
-        botState.bufferInterval = setInterval(async () => {
-            clear_req_buffer(botState);
-        }, 1 * 120000);
 
         clear_sale_data(botState);
         botState.saleOngoing = true;

--- a/main.js
+++ b/main.js
@@ -13,11 +13,9 @@ let botState = {
     prefix: PREFIX,
     saleOngoing: false,
     takingOrders: false,
-    bufferInterval: null,
     saleData: {
         queue: new Queue(),
         store: 0,
-        reqBuffer: [],
         totalSales: 0,
     },
 }
@@ -49,7 +47,11 @@ client.on("message", (message) => {
     if (!message.content.startsWith(prefix) || message.author.bot) return;
 
     const args = message.content.slice(prefix.length).split(/ +/);
-    const command = args.shift().toLowerCase();
+    let command = args.shift().toLowerCase();
+    
+    if (5 <= command.split("vaffelstop").at(1)?.filter((c) => c === 'p').length) {
+        command = "vaffelfullstop";
+    }
 
     switch (command) {
         case "vaffel":
@@ -63,6 +65,9 @@ client.on("message", (message) => {
             break;
         case "vaffelstop":
             client.commands.get("vaffelstop").execute(message, args, botState);
+            break;
+        case "vaffelfullstop":
+            client.commands.get("vaffelfullstop").execute(message, args, botState);
             break;
         case "salg":
             client.commands.get("salg").execute(message, args, botState);

--- a/main.js
+++ b/main.js
@@ -49,9 +49,18 @@ client.on("message", (message) => {
     const args = message.content.slice(prefix.length).split(/ +/);
     let command = args.shift().toLowerCase();
     
-    if (5 <= command.split("vaffelstop").at(1)?.filter((c) => c === 'p').length) {
+    const trail = command.split("vaffelstop").at(1);
+    if (trail !== undefined && 5 <= Array.from(trail).filter((c) => c === 'p').length) {
         command = "vaffelfullstop";
     }
+
+    if (command !== "vaffel" && command.includes("vaffel")) {
+        const negativesCount = (command.match(/stop|anti|ikke|itte|contra|kontra/g) || []).length;
+        if (0 < negativesCount) {
+            command = negativesCount % 2 === 1 ? "vaffelstop" : "vaffelstart";
+        }
+    }
+        
 
     switch (command) {
         case "vaffel":

--- a/util/state_functions.js
+++ b/util/state_functions.js
@@ -5,12 +5,7 @@ module.exports = {
         botState.saleData = {
             queue: new Queue(),
             store: 0,
-            reqBuffer: [],
             totalSales: 0,
         }
-    },
-    clear_req_buffer(botState) {
-        let { reqBuffer } = botState.saleData;
-        reqBuffer = [];
     },
 };


### PR DESCRIPTION
Heisann.

Jeg gjorde slik at `vaffelstopp` kun hindrer nye bestillinger uten å kansellere salget helt. Den gamle funksjonaliteten (resette salgsdata e.t.c.) er nå flyttet til `vaffelfullstopp` som også kan bli kalt på ved å skrive `vaffelstopp` med minst 5 `p`-er (ex. `vaffelstoppppppp`).

Siden det nå begynner å bli litt vanskelig å huske forksjell på `vaffelstopp`, `vaffelfullstop` or `vaffelstart` har jeg nå også laget et par ekstra aliaser til `vaffelstart` og `vaffelstop` som tar riktig hensyn til gramatikk, ved at de tar hensyn til *double negatives*.  Aliasene kan bli brukt med å gjøre "vaffel" sammen med ett eller flere av ordene: "stop", "anti", "ikke", "itte", contra" og "kontra". Ex.:
 - `vaffelstart` = `ikkevaffelstop` = `vaffelstopstop` = `antiikkevaffel` = `antiikkevaffelstoppkontra`
 - `vaffelstop` = `ikkevaffelstart` = `kontravaffelstopstop`